### PR TITLE
Append rather than replace chpwd_functions to prevent conflicts

### DIFF
--- a/virtualenv-autodetect.sh
+++ b/virtualenv-autodetect.sh
@@ -86,6 +86,6 @@ _virtualenv_auto_activate
 
 # Activate on directory change.
 # Zsh.
-chpwd_functions=(_virtualenv_auto_activate)
+chpwd_functions+=(_virtualenv_auto_activate)
 # Bash.
 export PROMPT_COMMAND="_bash_chpwd_function _virtualenv_auto_activate"


### PR DESCRIPTION
When using as a oh-my-zsh plugin, it would stop other plugins from hooking into chpwd_functions. This appends it, so it doesn't remove the previous ones.