### PR TITLE
Re-enable prompt

### DIFF
--- a/virtualenv-autodetect.sh
+++ b/virtualenv-autodetect.sh
@@ -16,7 +16,6 @@ _virtualenv_auto_activate() {
         if [ "$VIRTUAL_ENV" != "${_virtualenv_path%/bin/activate}" ]
         then
             _remove_from_pythonpath     # Remove any previous VE path
-            VIRTUAL_ENV_DISABLE_PROMPT=1
             source "$_virtualenv_path"
             _add_to_pythonpath "$VIRTUAL_ENV"
         fi


### PR DESCRIPTION
I think it would be best to allow users to configure this setting separately, outside of this function. Should be easy enough. As it is, it's not possible to re enable the prompt without modifying this function.