### PR TITLE
Better support for nested python projects

### DIFF
--- a/virtualenv-autodetect.sh
+++ b/virtualenv-autodetect.sh
@@ -40,7 +40,7 @@ _remove_from_pythonpath() {
 _get_virtualenv_path() {
     # Find subdir of given one that is a virtualenv dir.
     _find_virtualenv_subdir() {
-        result=$(find $1 -maxdepth 2 -type d -name 'bin' -exec find {} -name 'activate' \; 2> /dev/null)
+        result=$(find $1 -maxdepth 2 -type d -name 'bin' -exec find {} -maxdepth 1 -name 'activate' \; 2> /dev/null)
         if [ -n "$result" ]; then
             if [ -n "$(head -1 $result | grep "source bin/activate" 2> /dev/null)" ]; then
                 echo $result


### PR DESCRIPTION
When entering a folder that contains lots of Python projects, this prevents the activation of an environment until we actually enter on of the project folders.

This also improves the performance of deactivating and exiting the method if we are already inside an Virtual environment or if we leave the virtual environment's parent directory.